### PR TITLE
Update command_builder.py

### DIFF
--- a/fastflix/encoders/vvc/command_builder.py
+++ b/fastflix/encoders/vvc/command_builder.py
@@ -107,12 +107,12 @@ def build(fastflix: FastFlix):
 
     if settings.bitrate:
         command_1 = (
-            f'{beginning} {get_vvc_params(["pass=1", "no-slow-firstpass=1"])} '
-            f'-passlogfile "{pass_log_file}" -b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} '
+            f'{beginning} {get_vvc_params(["pass=1", "rcstatsfile={pass_log_file}"])} '
+            f'-b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra if settings.extra_both_passes else ""} '
             f" -an -sn -dn {output_fps} -f mp4 {null}"
         )
         command_2 = (
-            f'{beginning} {get_vvc_params(["pass=2"])} -passlogfile "{pass_log_file}" '
+            f'{beginning} {get_vvc_params(["pass=2", "rcstatsfile={pass_log_file}"])} '
             f"-b:v {settings.bitrate} -preset:v {settings.preset} {settings.extra} {ending}"
         )
         return [
@@ -122,7 +122,7 @@ def build(fastflix: FastFlix):
 
     elif settings.qp:
         command = (
-            f"{beginning} {get_vvc_params()}  -qp:v {settings.qp} "
+            f"{beginning} {get_vvc_params()}  -qp:v {settings.qp} -b:v 0"
             f"-preset:v {settings.preset} {settings.extra} {ending}"
         )
         return [Command(command=command, name="Single pass CRF", exe="ffmpeg")]


### PR DESCRIPTION
There was an issue submitted in the VVenC repository: [https://github.com/fraunhoferhhi/vvenc/issues/315](https://github.com/fraunhoferhhi/vvenc/issues/315)  
This PR fixes the issues concerning fix QP mode and logfile for 2pass rate control:
- fixing constant QP mode as it is currently not working (as long as video target bitrate is not set 0, the QP is ignored and the default ffmpeg bitrate of 200kbit/s is used)
- set rate control statsfile with param `rcstatsfile` as `passlogfile` is not available for VVenC
- removing `no-slow-firstpass=1` as it is not known in VVenC